### PR TITLE
Fix relative URL resolution for script sources in web technology detection

### DIFF
--- a/wappalyzer/core/analyzer.py
+++ b/wappalyzer/core/analyzer.py
@@ -18,13 +18,11 @@ from wappalyzer.core.requester import get_response
 from wappalyzer.core.utils import create_result
 
 
-def process_scripts(scheme, base_url, js, scriptSrc):
+def process_scripts(base_url, js, scriptSrc):
     def fetch_and_process(src):
-        # Ensure the URL is complete
-        src = urljoin(base_url, src)
         if src.endswith('.js') or '.js?' in src:
             js_code = get_response(src)
-            if js_code and js_code.headers.get('Content-Type', '').startswith('application/javascript'):
+            if js_code and js_code.headers['Content-Type'].startswith('application/javascript'):
                 js_dict, low_dict, js_classes = get_js(js_code.text)
                 if js_dict:
                     return {'dict': js_dict, 'low_dict': low_dict, 'classes': js_classes, 'src': src}
@@ -36,13 +34,13 @@ def process_scripts(scheme, base_url, js, scriptSrc):
             result = future.result()
             if result:
                 js.append({'dict': result['dict'], 'low_dict': result['low_dict'], 'classes': result['classes']})
-                # Resolve new script sources to absolute URLs
-                scriptSrc.extend(
-                    [urljoin(base_url, new_src) for new_src in get_scriptSrc(scheme, get_response(result['src']).text)]
-                )
-
+                # Pass base_url for proper URL resolution
+                js_code_response = get_response(result['src'])
+                if js_code_response:
+                    scriptSrc.extend(get_scriptSrc(base_url, js_code_response.text))
 
 def analyze_from_response(response, scan_type):
+    # prepare common info
     soup = BeautifulSoup(response.text, 'html.parser')
     r = tldextract.extract(response.url)
     domain = r.domain + '.' + r.suffix
@@ -51,19 +49,14 @@ def analyze_from_response(response, scan_type):
     base_url = f'{scheme}://{hostname}'
 
     js = []
-    scriptSrc = get_scriptSrc(scheme, soup)
+    scriptSrc = get_scriptSrc(response.url, soup)
     for script in soup.find_all('script'):
-        if script.get('src'):
-            src = script['src']
-            # Resolve relative URLs to absolute URLs
-            src = urljoin(base_url, src)
-            scriptSrc.append(src)
-        else:
+        if not script.get('src'):
             js_dict, low_dict, js_classes = get_js(script.text)
             if js_dict:
                 js.append({'dict': js_dict, 'low_dict': low_dict, 'classes': js_classes})
     if scan_type != 'fast':
-        process_scripts(scheme, base_url, js, scriptSrc)
+        process_scripts(response.url, js, scriptSrc) # Pass response.url instead of scheme
 
     if scan_type != 'fast':
         dns = get_dns(domain)

--- a/wappalyzer/parsers/scriptSrc.py
+++ b/wappalyzer/parsers/scriptSrc.py
@@ -1,27 +1,30 @@
 import re
+from urllib.parse import urljoin, urlparse
 
 url_pattern = r'(?:https?:)?//[\w.-]{2,}\.[a-zA-Z]{2,63}(?:[^\'"\s\n]+)?'
 
-def get_urls_from_js(scheme, js):
+def get_urls_from_js(base_url, js):
     scriptSrc = []
     matches = re.findall(url_pattern, js)
     for each in matches:
         if each.startswith('//'):
+            scheme = urlparse(base_url).scheme
             each = scheme + ':' + each
         scriptSrc.append(each)
     return scriptSrc
 
-def get_scriptSrc(scheme, soup):
+def get_scriptSrc(base_url, soup):
     if type(soup) == str:
-        return get_urls_from_js(scheme, soup)
+        return get_urls_from_js(base_url, soup)
 
+    scheme = urlparse(base_url).scheme
     scriptSrc = []
     for script in soup.find_all('script'):
         src = script.get('src')
         if src:
-            if src.startswith('//'):
-                src = scheme + ':' + src
+            # Use urljoin to handle all types of URLs (absolute, protocol-relative, and path-relative)
+            src = urljoin(base_url, src)
             scriptSrc.append(src)
         else:
-            scriptSrc.extend(get_urls_from_js(scheme, script.text))
+            scriptSrc.extend(get_urls_from_js(base_url, script.text))
     return scriptSrc


### PR DESCRIPTION
**Problem**
The script detection system doesn't correctly handle relative URLs in script sources. When a script source URL starts with `/` (indicating a path relative to the root of the website), it's not properly converted to an absolute URL. Only protocol-relative URLs starting with `//` are currently handled.

**Changes**
Modified `parsers/scriptSrc.py` to use urljoin() for all URL types
Updated `analyze_from_response()` in `core/analyzer.py` to pass full base URL
Updated `process_scripts()` in `core/analyzer.py` for proper URL resolution
Enhanced URL resolution in `get_urls_from_js()` for JavaScript URLs

**Benefits**
Properly handles all types of URLs found in script sources
Correctly resolves paths like `/cdn-cgi/scripts/...` to their absolute form
Makes the code more robust by using Python's standard URL handling capabilities
Ensures consistent URL handling throughout the technology detection process