### PR TITLE
Update meta.py

### DIFF
--- a/wappalyzer/parsers/meta.py
+++ b/wappalyzer/parsers/meta.py
@@ -1,5 +1,14 @@
 def get_meta(soup):
     meta = {}
     for tag in soup.find_all('meta'):
-        meta[tag.get('name')] = tag.get('content')
+        key = tag.get('name') or tag.get('property')
+        value = tag.get('content')
+        if key and value:
+            if key in meta:
+                if isinstance(meta[key], list):
+                    meta[key].append(value)
+                else:
+                    meta[key] = [meta[key], value]
+            else:
+                meta[key] = value
     return meta


### PR DESCRIPTION
The original `get_meta` function collects meta tags by their `name` attribute and stores the corresponding `content` value. However, it does not handle cases where multiple meta tags share the same name, which causes data to be overwritten.

The updated `get_meta` function addresses this issue by:

* Checking both `name` and `property` attributes as keys.
* Collecting multiple meta tag contents under the same key into a list instead of overwriting.
* Ensuring that keys are only added if both key and value exist.

This fix is particularly useful for cases like:

```html
<meta name="generator" content="WordPress 6.8.1" />
<meta name="generator" content="Site Kit by Google 1.153.0" />
```

where multiple meta tags share the same name but have different content values.