### PR TITLE
Keep version empty string even with optional group

### DIFF
--- a/wappalyzer/core/matcher.py
+++ b/wappalyzer/core/matcher.py
@@ -15,7 +15,8 @@ foo\\1   Returns foo with the first match appended.
 
 def group_or_literal(option, match):
     if option.startswith('\\'):
-        return match.group(int(option[1:]))
+        # when there is an optional group in the matching regex, that group may not exist.
+        return match.group(int(option[1:])) or ''
     return option
 
 def get_version(match, version_type):

--- a/wappalyzer/core/matcher.py
+++ b/wappalyzer/core/matcher.py
@@ -15,7 +15,6 @@ foo\\1   Returns foo with the first match appended.
 
 def group_or_literal(option, match):
     if option.startswith('\\'):
-        # when there is an optional group in the matching regex, that group may not exist.
         return match.group(int(option[1:])) or ''
     return option
 


### PR DESCRIPTION
Hello, I'm using a part of this library and sometimes `version` is None when a regex with an optional version group matches. 
For example, the regex: `nginx(?:/([\\d.]+))?` matches the value `"nginx"`, but the capturing version group does not exists.

In that case, when used in the `match` function, as version is compared to a string, this leads to an Exception.
https://github.com/s0md3v/wappalyzer-next/blob/94d71fb1c5e1f88b1a2394a19a4597819c4bd611/wappalyzer/core/matcher.py#L85-L87

Feel free to close it as my use case is maybe different than the expected usage.