### PR TITLE
fix error when js variable is a number

### DIFF
--- a/wappalyzer/parsers/js.py
+++ b/wappalyzer/parsers/js.py
@@ -131,7 +131,6 @@ def get_js(js_code: str) -> dict:
             # Handle undefined
             if value.lower() == 'undefined':
                 return None
-            # Handle numbers: keep value as string as regexes are matched on string
             # Handle strings with quotes
             if (value.startswith('"') and value.endswith('"')) or \
                (value.startswith("'") and value.endswith("'")):


### PR DESCRIPTION
Fix for Issue #23 where JS variables transformed into numbers cannot be used later.