### PR TITLE
fix js boolean value not transformed into a string

### DIFF
--- a/wappalyzer/core/matcher.py
+++ b/wappalyzer/core/matcher.py
@@ -97,7 +97,9 @@ def match_dict(pattern_dict, response_dict):
         if name in response_dict:
             values = response_dict[name]
             if not isinstance(values, list):
-                values = [values]
+                if isinstance(values, bool):
+                    values = str(values).lower()
+                values = [str(values)]
             for value in values:
                 if pattern == '':
                     return True, '', 100


### PR DESCRIPTION
The proposed changes fix the issue #29 that generates an error when a boolean value is found in a matching JS variable.

When a value is not a list, a boolean value is lowercased. Then, all values are casted into a list of strings.