### PR TITLE
Add wait time argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Some common usage examples are given below, refer to list of all options for mor
 - `-oC`: CSV output file path
 - `-oH`: HTML output file path
 - `-c, --cookie`: Cookie header string for authenticated scans
+- `--wait-time`: Amount of seconds to wait for browser-based JavaScript execution in `full` scans (default: 5)
 
 ## For Developers
 
@@ -120,7 +121,8 @@ results = analyze(
     url='https://example.com',
     scan_type='full',  # 'fast', 'balanced', or 'full'
     threads=3,
-    cookie='sessionid=abc123'
+    cookie='sessionid=abc123',
+    wait_time=5
 )
 ```
 
@@ -133,6 +135,7 @@ results = analyze(
   - `'full'`: Complete scan including JavaScript execution (default)
 - `threads` (int, optional): Number of threads for parallel processing (default: 3)
 - `cookie` (str, optional): Cookie header string for authenticated scans
+- `wait_time` (int, optional): Amount of seconds to wait for JavaScript/browser interactions in `'full'` scans (default: 5)
 
 #### Return Value
 

--- a/wappalyzer/__main__.py
+++ b/wappalyzer/__main__.py
@@ -13,7 +13,7 @@ from wappalyzer.core.analyzer import http_scan
 from wappalyzer.core.utils import pretty_print, write_to_file
 from wappalyzer.browser.analyzer import DriverPool, cookie_to_cookies, process_url, merge_technologies
 
-def analyze(url, scan_type='full', threads=3, cookie=None):
+def analyze(url, scan_type='full', threads=3, cookie=None, wait_time=5):
     """Analyze a single URL"""
     if scan_type.lower() == 'full':
         driver_pool = None
@@ -23,7 +23,7 @@ def analyze(url, scan_type='full', threads=3, cookie=None):
                 if cookie:
                     for cookie_dict in cookie_to_cookies(cookie):
                         driver.add_cookie(cookie_dict)
-                url, detections = process_url(driver, url)
+                url, detections = process_url(driver, url, wait_time=wait_time)
                 return {url: merge_technologies(detections)}
         finally:
             if driver_pool:
@@ -42,13 +42,17 @@ def main():
     parser.add_argument('-oC', help='csv output file', dest='csv_output_file')
     parser.add_argument('-oH', help='html output file', dest='html_output_file')
     parser.add_argument('-c', '--cookie', help='cookie string', dest='cookie')
+    parser.add_argument('--wait-time', help='seconds to wait for browser', dest='wait_time', default=5, type=int)
     args = parser.parse_args()
 
     print('\n\t' + bold(green('wappalyzer')) + '\n')
     if not args.input_file:
         parser.print_help()
         exit(22)
-    
+    if args.wait_time <= 0:
+        print("--wait-time must be greater than 0.")
+        exit(22)
+
     result_db = {}
 
     def process_detections(url_detections, scan_type='full'):
@@ -60,13 +64,13 @@ def main():
                 result[url] = detections
         return result
 
-    def process_urls(urls, num_threads=3, cookie=None, scan_type='full', should_print=False):
+    def process_urls(urls, num_threads=3, cookie=None, scan_type='full', should_print=False, wait_time=5):
         """Process multiple URLs using a driver pool"""
         results = {}
         driver_pool = None
         interrupted = False
         
-        def worker(worker_id, url_queue, result_queue, lock, cookie, scan_type='full'):
+        def worker(worker_id, url_queue, result_queue, lock, cookie, scan_type='full', wait_time=5):
             """Process URLs from the queue"""
             try:
                 while not interrupted:
@@ -82,7 +86,7 @@ def main():
                                 if cookie:
                                     for cookie_dict in cookie_to_cookies(cookie):
                                         driver.add_cookie(cookie_dict)
-                                url, detections = process_url(driver, url)
+                                url, detections = process_url(driver, url, wait_time=wait_time)
                                 if detections:
                                     with lock:
                                         result_queue.put((url, detections))
@@ -111,7 +115,7 @@ def main():
             for i in range(num_threads):
                 thread = threading.Thread(
                     target=worker,
-                    args=(i, url_queue, result_queue, lock, cookie, scan_type)
+                    args=(i, url_queue, result_queue, lock, cookie, scan_type, wait_time)
                 )
                 thread.daemon = True
                 thread.start()
@@ -160,7 +164,7 @@ def main():
     try:
         if re.search(r'^https?://', args.input_file.lower()):
             should_print = not (args.json_output_file or args.csv_output_file or args.html_output_file)
-            result = analyze(args.input_file, args.scan_type, args.thread_num, args.cookie)
+            result = analyze(args.input_file, args.scan_type, args.thread_num, args.cookie, args.wait_time)
             if should_print:
                 pretty_print(result)
         else:
@@ -169,11 +173,11 @@ def main():
                 urls = urls_file.read().splitlines()
                 urls_file.close()
                 should_print = not (args.json_output_file or args.csv_output_file or args.html_output_file)
-                result = process_urls(urls, args.thread_num, args.cookie, args.scan_type, should_print=should_print)
+                result = process_urls(urls, args.thread_num, args.cookie, args.scan_type, should_print=should_print, wait_time=args.wait_time)
             except FileNotFoundError:
                 if tldextract.extract('http://' + args.input_file).domain != '':
                     should_print = not (args.json_output_file or args.csv_output_file or args.html_output_file)
-                    result = analyze('http://' + args.input_file, args.scan_type, args.thread_num, args.cookie)
+                    result = analyze('http://' + args.input_file, args.scan_type, args.thread_num, args.cookie, args.wait_time)
                     if should_print:
                         pretty_print(result)
                 else:

--- a/wappalyzer/browser/analyzer.py
+++ b/wappalyzer/browser/analyzer.py
@@ -131,20 +131,20 @@ def cookie_to_cookies(cookie):
             })
     return cookies
 
-def process_url(driver, url):
+def process_url(driver, url, wait_time=5):
     try:
         main_tab = driver.current_window_handle
         initial_handles = set(driver.window_handles)
         
         driver.get(url)
         
-        for i in range(5):
+        for _ in range(wait_time):
             driver.switch_to.window(main_tab)
             driver.execute_script("window.scrollTo(0, Math.random() * 1000)")
             driver.execute_script("var event = new MouseEvent('mousemove', { 'view': window, 'bubbles': true, 'cancelable': true, 'clientX': Math.random() * window.innerWidth, 'clientY': Math.random() * window.innerHeight }); document.dispatchEvent(event);")
             time.sleep(1)
-        
-        # after 5 seconds, process the right-most tab
+
+        # process the right-most tab after wait time has elapsed
         current_handles = driver.window_handles
         if len(current_handles) > 1:
             rightmost_handle = current_handles[-1]


### PR DESCRIPTION
Hi, 

I encountered an issue where, in environments where it took longer than 5 seconds for the browser to execute the JavaScript, the results were very limited. I was running the command in a Docker container on a system with limited resources. It took some time to figure out what was causing this, since it only caused problems for certain URLs. 

If I increase the wait time to, say, 15 seconds, the results match what I get in my local browser. That’s why I added an option that allows you to increase the wait time. It would be great if this option could be added to the repo, because I think it could help people with use cases similar to mine. 