### PR TITLE
Increase geckodriver version to 0.36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN apt-get update && apt-get install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-linux64.tar.gz \
-    && tar -xvzf geckodriver-v0.35.0-linux64.tar.gz \
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz \
+    && tar -xvzf geckodriver-v0.36.0-linux64.tar.gz \
     && mv geckodriver /usr/local/bin/ \
-    && rm geckodriver-v0.35.0-linux64.tar.gz
+    && rm geckodriver-v0.36.0-linux64.tar.gz
 
 RUN pip install --no-cache-dir wappalyzer
 


### PR DESCRIPTION
Hi,

In my experience the docker setup does not work out of the box. I had to increase the geckodriver version to 0.36 to get it working. It seems the newest version of firefox is not compatible with version 0.35. 

If someone can confirm this, I hope this PR could be merged so it saves other people some time debugging. 